### PR TITLE
小説の削除機能実装

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -1,5 +1,8 @@
 class NovelsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_novel, only: [:show, :destroy]
+  before_action :unless_novel_user, only: [:destroy]
+
   def index
     @novels = Novel.all.order("created_at DESC")
   end
@@ -19,11 +22,26 @@ class NovelsController < ApplicationController
   end
 
   def show
-    @novel = Novel.find(params[:id])
+  end
+
+  def destroy
+    if @novel.destroy
+      redirect_to "/"
+    end
   end
 
   private
   def novel_params
     params.require(:novel).permit(:title, :content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_novel
+    @novel = Novel.find(params[:id])
+  end
+
+  def unless_novel_user
+    unless current_user.id == @novel.user_id
+      redirect_to "/"
+    end
   end
 end

--- a/app/views/novels/show.html.erb
+++ b/app/views/novels/show.html.erb
@@ -4,7 +4,7 @@
   <div class="two-btns">
     <% if user_signed_in? && current_user.id == @novel.user.id %>
       <%= link_to "添削", "#", class: "edit-btn" %>
-      <%= link_to "破棄", "#", class: "destroy-btn" %>
+      <%= link_to "破棄", novel_path(@novel), method: :delete, class: "destroy-btn" %>
     <% end %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "novels#index"
-  resources :novels, only: [:index, :new, :create, :show]
+  resources :novels, only: [:index, :new, :create, :show, :destroy]
 end


### PR DESCRIPTION
### why
ユーザーが自身の小説を削除できるようにするため
### what
小説削除に関するコントローラ(destroy)、ビュー、投稿者以外が削除でいないように制限
### url about destroy
投稿者とログインユーザーが一致していると削除できる
https://gyazo.com/3f2ce813cf8adaa1289c341c645a9cc8
投稿者以外のログインユーザーが削除しようとするとトップページに戻され、削除されない(挙動確認用に削除ボタンを表示しています)
https://gyazo.com/f12fa35e73c20987d4e03577668c1855
ログインしていないユーザーが削除しようとするとログインページに戻される(挙動確認用に削除ボタンを表示しています。)
https://gyazo.com/7b6f9f7762291c22883d301eb1317585