### PR TITLE
改良

### DIFF
--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -1,7 +1,7 @@
 class Novel < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  has_many :tips
+  has_many :tips, dependent: :destroy
 
   with_options presence: true do
     validates :title, :content


### PR DESCRIPTION
### why
tipモデルを紐づけたことにより旧バージョンでは小説を削除できなくなっていたため

### what
novelモデルのファイルのtipとのアソシエーションの記述にdependent: :destroyを追記